### PR TITLE
Prevent Buffer deprecation warning

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ function plugin (options) {
             }
 
             if (formatted) {
-                data.contents = new Buffer(formatted);
+                data.contents = Buffer.from(formatted);
             }
         });
         done();


### PR DESCRIPTION
(node:6946) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.